### PR TITLE
Revert "Add note re. logging"

### DIFF
--- a/docs/integrations/hive-metastore.md
+++ b/docs/integrations/hive-metastore.md
@@ -67,10 +67,6 @@ The scheme must be `thrift+hms`. The `+hms` suffix is required to distinguish th
 | UNIONTYPE                       | UnionType |
 | STRUCT                      | StructType |
 
-## Logging
-
-By default the Hive Metastore will log at INFO level. You can override this by setting the `HMS_LOGLEVEL` environment variable for the container.
-
 ## Limitations and Constraints
 
 The conversion functions raise a `ValueError` exception if the conversion is not possible.


### PR DESCRIPTION
Reverts recap-build/recap-website#14

I'm dumb. Realized @rmoff's PR was for the HMS standalone repo... https://github.com/recap-build/hive-metastore-standalone

I'm removing this from the docs since it's nothing to do with Recap's HMS integration.